### PR TITLE
Fix UTC usage

### DIFF
--- a/ibind/support/logs.py
+++ b/ibind/support/logs.py
@@ -1,5 +1,4 @@
 import datetime
-
 import logging
 import sys
 from pathlib import Path

--- a/ibind/support/logs.py
+++ b/ibind/support/logs.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+import datetime
 
 import logging
 import sys
@@ -128,7 +128,7 @@ class DailyRotatingFileHandler(logging.FileHandler):
         super().__init__(*args, **kwargs)
 
     def get_timestamp(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.datetime.now(datetime.timezone.utc)
         return now.strftime(self.date_format)
 
     def get_filename(self, timestamp):

--- a/ibind/support/logs.py
+++ b/ibind/support/logs.py
@@ -1,4 +1,5 @@
-import datetime
+from datetime import datetime, timezone
+
 import logging
 import sys
 from pathlib import Path
@@ -127,7 +128,7 @@ class DailyRotatingFileHandler(logging.FileHandler):
         super().__init__(*args, **kwargs)
 
     def get_timestamp(self):
-        now = datetime.datetime.now(datetime.UTC)
+        now = datetime.now(timezone.utc)
         return now.strftime(self.date_format)
 
     def get_filename(self, timestamp):


### PR DESCRIPTION
Hello @Voyz 
Thank you for ibind / ibeam. I was trying to use your library and calling `ibind_logs_initialize()` failed for me with:

```
    now = datetime.datetime.now(datetime.UTC)
AttributeError: module 'datetime' has no attribute 'UTC'
```
I thought this might fix it so I applied the fix: https://stackoverflow.com/a/13624191

It fixed the issue for me but I am not used to committing to Python repos so you can guide me on whether this needs further work.

Best,