### PR TITLE
Use the correct url for get_all_watchlists endpoint.

### DIFF
--- a/ibind/client/ibkr_client_mixins/watchlist_mixin.py
+++ b/ibind/client/ibkr_client_mixins/watchlist_mixin.py
@@ -39,7 +39,7 @@ class WatchlistMixin():  # pragma: no cover
         Parameters:
             SC (str): Optional. Specify the scope of the request. Valid Values: USER_WATCHLIST.
         """
-        return self.get('iserver/watchlist', params={'SC': sc})
+        return self.get('iserver/watchlists', params={'SC': sc})
 
     def get_watchlist_information(self: 'IbkrClient', id: str) -> Result:
         """


### PR DESCRIPTION
according to https://www.interactivebrokers.com/campus/ibkr-api-page/webapi-ref/#tag/Trading-Watchlists/paths/~1iserver~1watchlists/get

the url is `iserver/watchlists`