### PR TITLE
added new optional parameter "exchange" to "security_future_by_symbol…

### DIFF
--- a/ibind/client/ibkr_client_mixins/contract_mixin.py
+++ b/ibind/client/ibkr_client_mixins/contract_mixin.py
@@ -227,14 +227,21 @@ class ContractMixin():
         return self.get(f'iserver/secdef/strikes', params)
 
     @ensure_list_arg('symbols')
-    def security_future_by_symbol(self: 'IbkrClient', symbols: OneOrMany[str]) -> Result:  # pragma: no cover
+    def security_future_by_symbol(self: 'IbkrClient', symbols: OneOrMany[str], exchange: str = None) -> Result:  # pragma: no cover
         """
         Returns a list of non-expired future contracts for given symbol(s).
 
         Parameters:
             symbols (str): Indicate the symbol(s) of the underlier you are trying to retrieve futures on. Accepts list of string of symbols.
+            exchange (str, optional): Exchange from which futures should be retrieved from. Default value is set to None, means "All exchanges". 
         """
-        return self.get(f'trsrv/futures', {'symbols': ','.join(symbols)})
+        params = params_dict(
+            {
+                'symbols': ','.join(symbols)
+            },
+            optional={'exchange': exchange}
+        )
+        return self.get(f'trsrv/futures', params)
 
     @ensure_list_arg('queries')
     def security_stocks_by_symbol(self: 'IbkrClient', queries: StockQueries, default_filtering: bool = True) -> Result:


### PR DESCRIPTION
…" to accomodate Web-Api from IBKR.  defaults to None

It is needed if a future comes from different exchanges.
Without this param you get all contracts from all exchanges in the result.

Example:l "AUD".

