### PR TITLE
Move price to be an optional arg in make_order_request

### DIFF
--- a/ibind/client/ibkr_utils.py
+++ b/ibind/client/ibkr_utils.py
@@ -253,10 +253,10 @@ def make_order_request(
         side: str,
         quantity: float,
         order_type: str,
-        price: float,
         acct_id: str,
 
         # optional
+        price: float = None,
         conidex: str = None,
         sec_type: str = None,
         coid: str=None,


### PR DESCRIPTION
This change:

https://github.com/Voyz/ibind/commit/bebdf5157a772ff32d8b9298afcfcd5b0a01aba4#diff-0b021b88fb62714e150cc0b534c535173f77f29785a85da9549ec1f2586c8b85R37

exposes the fact that price is a required argument, which doesn't make sense for market orders - I think it makes sense for it to be made optional if the intention is to use market orders as the base case in examples.