### PR TITLE
patched definitions for market request to be complete

### DIFF
--- a/ibind/client/ibkr_definitions.py
+++ b/ibind/client/ibkr_definitions.py
@@ -12,6 +12,14 @@ snapshot_by_key = {
     'market_data_availability': '6509',  # Market Data Availability. The field may contain three chars. First char defines: R = RealTime, D = Delayed, Z = Frozen, Y = Frozen Delayed, N = Not Subscribed. Second char defines: P = Snapshot, p = Consolidated. Third char defines: B = Book
     'conid_exchange': '7094',  # Conid + Exchange
 
+    ##Regulator snapshot
+    'ask_codes':'7057', # Returns the series of character codes for the Ask exchange.
+
+    'bid_codes': '7068', #Returns the series of character codes for the Bid exchange.
+
+    'last_exch_codes': '7058', #Returns the series of character codes for the Last exchange.
+
+
     # Price and Volume
     'open': '7295',  # Open - Today's opening price.
     'high': '70',  # High - Current day high price


### PR DESCRIPTION
fully specified market data request:

e.g. Result(data={'conid': 72539702, 'conidEx': '72539702', 'sizeMinTick': 1.0, 'BboExchange': '9c', 'HasDelayed': False, 'BestBidExch': 512, 'BestAskExch': 448321, 'LastExch': 8, 'bid_price': '70.76', 'ask_price': '70.77', 'bid_size': 1, 'ask_size': 139, 'last_price': '70.78', 'last_size': 25, 'ask_codes': 'AKPQVXZNUH', 'bid_codes': 'Q', 'last_exch_codes': 'D'}, request={'url': 'https://localhost:5000/v1/api/md/regsnapshot', 'params': {'conid': 72539702}})