### PR TITLE
Fix Shutdown OAuth Register

### DIFF
--- a/ibind/base/rest_client.py
+++ b/ibind/base/rest_client.py
@@ -84,6 +84,7 @@ class RestClient:
             timeout: float = 10,
             max_retries: int = 3,
             use_session: bool = var.IBIND_USE_SESSION,
+            shutdown_oauth: bool = var.IBIND_SHUTDOWN_OAUTH,
     ) -> None:
         """
         Parameters:
@@ -115,7 +116,8 @@ class RestClient:
         if use_session:
             self.make_session()
 
-        self.register_shutdown_handler()
+        if shutdown_oauth:
+            self.register_shutdown_handler()
 
     def _make_logger(self):
         self._logger = new_daily_rotating_file_handler('RestClient', os.path.join(var.LOGS_DIR, f'rest_client'))

--- a/ibind/client/ibkr_client.py
+++ b/ibind/client/ibkr_client.py
@@ -81,13 +81,15 @@ class IbkrClient(RestClient, AccountsMixin, ContractMixin, MarketdataMixin, Orde
             self.oauth_config = cast(OAuth1aConfig, oauth_config) if oauth_config is not None else OAuth1aConfig()
             url = url if url is not None and self.oauth_config.oauth_rest_url is None else self.oauth_config.oauth_rest_url
 
+        shutdown_oauth = var.IBIND_SHUTDOWN_OAUTH if not self._use_oauth else self.oauth_config.shutdown_oauth
+
         if url is None:
             url = f'https://{host}:{port}{base_route}'
 
         self.account_id = account_id
 
         cacert = True if self._use_oauth else cacert
-        super().__init__(url=url, cacert=cacert, timeout=timeout, max_retries=max_retries, use_session=use_session)
+        super().__init__(url=url, cacert=cacert, timeout=timeout, max_retries=max_retries, use_session=use_session, shutdown_oauth=shutdown_oauth)
 
         self.logger.info('#################')
         self.logger.info(f'New IbkrClient(base_url={self.base_url!r}, account_id={self.account_id!r}, ssl={self.cacert!r}, timeout={self._timeout}, max_retries={self._max_retries}, use_oauth={self._use_oauth})')


### PR DESCRIPTION
With the latest changes in 0.1.12 the `register_shutdown_handler` was always registered. This caused a problem in some scenarios.

When using the IBind client inside a Django application, it's not possible (or at least not trivial) to register a `SIGTERM` handler, since those are only supported in the main thread.

The change in this MR simply recovers the support to use `oauth_config.shutdown_oauth` value to both, register and execute the shutdown handler.