### PR TITLE
Revert coverage badge with license

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ wrong? [Create an issue and let us know!][issues]*
     <a href="https://github.com/Voyz/ibind/releases">
         <img src="https://img.shields.io/pypi/v/ibind?label=version"/> 
     </a>
-    <a href="https://github.com/Voyz/ibind">
-        <img src="https://img.shields.io/badge/coverage-68%25-green.svg"/>
+    <a href="https://opensource.org/licenses/Apache-2.0">
+        <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"/>
     </a>
 </p>
 


### PR DESCRIPTION
Looks like I accidentally merged in the wrong change!  This removes coverage until we can get the codecov metric in and coverage up.

@Voyz 