### PR TITLE
fix(ws): pass skip_utf8_validation=True to run_forever to survive non-UTF-8 text frames

### DIFF
--- a/ibind/base/ws_client.py
+++ b/ibind/base/ws_client.py
@@ -162,7 +162,14 @@ class WsClient(SubscriptionController):
 
         try:
             # the timeout is set to a little sooner than the interval
-            wsa.run_forever(ping_interval=self._ping_interval, ping_timeout=self._ping_interval * 0.95, sslopt=self._sslopt)
+            # skip_utf8_validation=True: IBKR occasionally emits non-UTF-8 bytes (e.g. 0x99) in text frames,
+            # which crashes the run_forever thread before on_close fires. Decoding is handled above this layer.
+            wsa.run_forever(
+                ping_interval=self._ping_interval,
+                ping_timeout=self._ping_interval * 0.95,
+                sslopt=self._sslopt,
+                skip_utf8_validation=True,
+            )
 
         except ValueError as e:
             if 'url is invalid' in str(e):

--- a/test/integration/base/test_websocket_client_i.py
+++ b/test/integration/base/test_websocket_client_i.py
@@ -95,6 +95,7 @@ def _verify_started(ws_client: WsClient, wsa_mock: MagicMock):
         sslopt=ws_client._sslopt,
         ping_interval=ws_client._ping_interval,
         ping_timeout=0.95 * ws_client._ping_interval,
+        skip_utf8_validation=True,
     )
     wsa_mock._on_open.assert_called_with(wsa_mock)
 
@@ -260,6 +261,7 @@ def test_open_exception(ws_client, wsa_mock, thread_mock, thread_ctor_mock, patc
         sslopt: dict = None,
         ping_interval: float = 0,
         ping_timeout: Optional[float] = None,
+        skip_utf8_validation: bool = False,
     ):
         wsa_mock.run_forever.side_effect = old_run_forever
         raise RuntimeError(_ERROR_MESSAGE)

--- a/test/integration/base/websocketapp_mock.py
+++ b/test/integration/base/websocketapp_mock.py
@@ -41,7 +41,7 @@ def close(wsa_mock: MagicMock, status: str = None):
     wsa_mock._on_close(wsa_mock, None, None)
 
 
-def run_forever(wsa_mock: MagicMock, sslopt: dict = None, ping_interval: float = 0, ping_timeout: Optional[float] = None):
+def run_forever(wsa_mock: MagicMock, sslopt: dict = None, ping_interval: float = 0, ping_timeout: Optional[float] = None, skip_utf8_validation: bool = False):
     wsa_mock.keep_running = True
     wsa_mock._on_open(wsa_mock)
 


### PR DESCRIPTION
Hi maintainers,

Closes #148.

This PR fixes a silent WebSocket failure where `WsClient._run_websocket` calls `wsa.run_forever(...)` without `skip_utf8_validation=True`. When IBKR emits a text-opcode frame containing bytes outside the UTF-8 range (we've observed `0x99` in the wild on order/trade channels), `websocket-client`'s frame decoder raises `UnicodeDecodeError` inside its receive loop. The `run_forever` thread then dies before the close handshake completes, `on_close` never fires, the reconnect path is never triggered, and event delivery stops silently — no error, no reconnect, just a quiet stall.

Passing `skip_utf8_validation=True` lets raw bytes through to the application layer (where `WsClient` already wraps message handling in its own try/except), which is consistent with how the upstream `websocket-client` library expects this case to be handled.

**Key changes:**

- `ibind/base/ws_client.py`: pass `skip_utf8_validation=True` to `wsa.run_forever()` and a short `# why` comment naming the failure mode.
- `test/integration/base/test_websocket_client_i.py`: `_verify_started` now also asserts `skip_utf8_validation=True` is passed. Since this helper is shared by every happy-path test in the file (`test_start_success`, `test_start_success_on_second_attempt`, `test_open_and_close`, `test_send`, `test_check_ping`, …), the kwarg is regression-pinned. Also extended the local `run_forever_exception` mock signature in `test_open_exception` so the new kwarg doesn't TypeError-loop the reconnect path.
- `test/integration/base/websocketapp_mock.py`: extended the shared `run_forever` mock signature with `skip_utf8_validation: bool = False` for the same reason.

**Verification:**

- `pytest test/unit test/integration` → 78 passed locally.
- `make lint` is unchanged on the modified files.

**Notes:**

- Diff is intentionally minimal: 1 prod kwarg + 3 test/mock signature updates. No new behaviour, no API surface changes.
- We've been running this patch in production for several weeks with no regressions on well-formed frames.

Happy to adjust scope, comment, or test layout based on review.

Thanks!