### PR TITLE
ci: update checkout to v7 and setup-python to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Updates the CI workflow to current GitHub-maintained action versions.

Changes:
- `actions/checkout@v4` -> `actions/checkout@v7`
- `actions/setup-python@v3` -> `actions/setup-python@v7`

Validation:
- workflow YAML parses after the change
- setup-python v7 drops the pip-install input; this workflow only passes python-version, so nothing to migrate
- actions/checkout v7 blocks fork PR checkouts under pull_request_target; this workflow uses plain pull_request, unaffected

Scope: `.github/workflows/ci.yml` only.
